### PR TITLE
feat!: have tx builder return tx on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,34 +18,32 @@ npm install @ts-bitcoin/core
 ```ts
 import { Address, Bn, KeyPair, PrivKey, TxBuilder, TxOut, deps } from '@ts-bitcoin/core'
 
-const txb = new TxBuilder()
-
 // make change address
-const privKey1 = new PrivKey().fromRandom()
-const keyPair1 = new KeyPair().fromPrivKey(privKey1)
-const addr1 = new Address().fromPubKey(keyPair1.pubKey)
+const privKey1 = PrivKey.fromRandom()
+const keyPair1 = KeyPair.fromPrivKey(privKey1)
+const addr1 = Address.fromPubKey(keyPair1.pubKey)
 
 // make address to send from
-const privKey2 = new PrivKey().fromBn(new Bn(1))
-const keyPair2 = new KeyPair().fromPrivKey(privKey2)
-const addr2 = new Address().fromPubKey(keyPair2.pubKey)
+const privKey2 = PrivKey.fromBn(new Bn(1))
+const keyPair2 = KeyPair.fromPrivKey(privKey2)
+const addr2 = Address.fromPubKey(keyPair2.pubKey)
 
 const txOut = TxOut.fromProperties(new Bn(2e8), addr2.toTxOutScript())
 const txHashBuf = deps.Buffer.alloc(32).fill(0)
 
 // make address to send to
-const privKey3 = new PrivKey().fromBn(new Bn(2))
-const keyPair3 = new KeyPair().fromPrivKey(privKey3)
-const addr3 = new Address().fromPubKey(keyPair3.pubKey)
+const privKey3 = PrivKey.fromBn(new Bn(2))
+const keyPair3 = KeyPair.fromPrivKey(privKey3)
+const addr3 = Address.fromPubKey(keyPair3.pubKey)
 
-txb.setFeePerKbNum(0.0001e8)
-txb.setChangeAddress(addr1)
-txb.inputFromPubKeyHash(txHashBuf, 0, txOut, keyPair2.pubKey)
-txb.outputToAddress(new Bn(1e8), addr3)
+const tx = new TxBuilder()
+  .setFeePerKbNum(0.0001e8)
+  .setChangeAddress(addr1)
+  .inputFromPubKeyHash(txHashBuf, 0, txOut, keyPair2.pubKey)
+  .outputToAddress(new Bn(1e8), addr3)
+  .build()
 
-txb.build()
-
-const raw = txb.tx.toHex()
+const raw = tx.toHex()
 ```
 
 ## About

--- a/src/tx-builder.ts
+++ b/src/tx-builder.ts
@@ -367,8 +367,10 @@ export class TxBuilder extends Struct {
      * TxBuilder will not necessarily us all the inputs. To force the TxBuilder
      * to use all the inputs (such as if you wish to spend the entire balance
      * of a wallet), set the argument useAllInputs = true.
+     *
+     * @returns Built transaction.
      */
-    public build(opts = { useAllInputs: false }): this {
+    public build(opts = { useAllInputs: false }): Tx {
         let minFeeAmountBn
         if (this.txIns.length <= 0) {
             throw Error('tx-builder number of inputs must be greater than 0')
@@ -430,7 +432,7 @@ export class TxBuilder extends Struct {
             if (this.tx.txOuts.length === 0) {
                 throw new Error('outputs length is zero - unable to create any outputs greater than dust')
             }
-            return this
+            return this.tx
         } else {
             throw new Error('unable to gather enough inputs for outputs and fee')
         }

--- a/test/tx-builder.test.ts
+++ b/test/tx-builder.test.ts
@@ -362,7 +362,7 @@ describe('TxBuilder', () => {
             should(tx.txOuts[0].valueBn.toString()).be.eql(inputAmount.toString())
         })
 
-        it('should return the built transaction', function () {
+        it('should return the built transaction', () => {
             const txb = prepareTxBuilder()
 
             const tx = txb.build()

--- a/test/tx-builder.test.ts
+++ b/test/tx-builder.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
+import * as assert from 'assert'
 import should = require('should')
 import * as sinon from 'sinon'
 import { Address } from '../src/address'
@@ -359,6 +360,14 @@ describe('TxBuilder', () => {
 
             const tx = txb.tx
             should(tx.txOuts[0].valueBn.toString()).be.eql(inputAmount.toString())
+        })
+
+        it('should return the built transaction', function () {
+            const txb = prepareTxBuilder()
+
+            const tx = txb.build()
+            assert(tx instanceof Tx, 'should be instance of Tx')
+            assert(tx.hash().equals(txb.tx.hash()), 'should be the same tx')
         })
     })
 


### PR DESCRIPTION
BREAKING CHANGE: Allows usage of fluent api without assigning the tx builder to a separate variable.